### PR TITLE
Potential fix for code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "Go Building & Testing"
 
 on:

--- a/engine/engine_api.go
+++ b/engine/engine_api.go
@@ -1219,6 +1219,10 @@ func (e *storageEngine) Query(ctx context.Context, params core.QueryParams) (ite
 		// For a final aggregation over multiple series, the result key should be synthetic
 		// and represent the query, not a specific series. We'll use just the metric.
 		syntheticSeriesKey := core.EncodeSeriesKey(metricID, nil)
+		const maxSeriesKeyLen = 64 * 1024 // 64KB, adjust as appropriate
+		if len(syntheticSeriesKey) > maxSeriesKeyLen {
+			return nil, fmt.Errorf("series key too large (%d bytes), max allowed is %d", len(syntheticSeriesKey), maxSeriesKeyLen)
+		}
 		syntheticQueryStartKey := make([]byte, len(syntheticSeriesKey)+8)
 		copy(syntheticQueryStartKey, syntheticSeriesKey)
 		binary.BigEndian.PutUint64(syntheticQueryStartKey[len(syntheticSeriesKey):], uint64(params.StartTime))

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -8,6 +8,7 @@ import (
 	"hash/crc32"
 	"io"
 	"log/slog" // Import slog
+	"math"
 	"sync"
 	"sync/atomic"
 
@@ -68,7 +69,14 @@ func LoadSSTable(opts LoadSSTableOptions) (sst *SSTable, err error) {
 	if opts.Tracer != nil {
 		// Assuming context.Background() for internal operations not tied to a specific request context
 		_, span = opts.Tracer.Start(context.Background(), "SSTable.LoadSSTable")
-		span.SetAttributes(attribute.String("sstable.filepath", opts.FilePath), attribute.Int64("sstable.id", int64(opts.ID)))
+		var sstableIDint64 int64
+		if opts.ID <= uint64(math.MaxInt64) {
+			sstableIDint64 = int64(opts.ID)
+		} else {
+			sstableIDint64 = math.MaxInt64
+			opts.Logger.Warn("SSTable ID exceeds int64 range, using MaxInt64 for tracing attribute.", "sstable_id", opts.ID)
+		}
+		span.SetAttributes(attribute.String("sstable.filepath", opts.FilePath), attribute.Int64("sstable.id", sstableIDint64))
 		defer span.End()
 	}
 	// Ensure logger is not nil


### PR DESCRIPTION
Potential fix for [https://github.com/INLOpen/nexusbase/security/code-scanning/4](https://github.com/INLOpen/nexusbase/security/code-scanning/4)

To fix the problem, we should ensure that the conversion from `uint64` to `int64` only occurs if the value is within the valid range for `int64`. If `opts.ID` exceeds `math.MaxInt64`, we should either cap the value, use a default, or log a warning. Since the value is only used for tracing, the best approach is to check the bound and, if exceeded, set the attribute to a sentinel value (e.g., `math.MaxInt64`) or log a warning. This fix should be applied in `sstable/reader.go` at the point of conversion (line 71). We will need to import the `math` package to access `math.MaxInt64`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
